### PR TITLE
Move gensim to dependencies from pip

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -25,6 +25,7 @@ dependencies:
   - tzdata=2023c=h71feb2d_0
   - wheel=0.42.0=pyhd8ed1ab_0
   - xz=5.2.6=h166bdaf_0
+  - gensim=3.8.3
   - pip:
       - aiohttp==3.9.1
       - aiosignal==1.3.1
@@ -58,7 +59,6 @@ dependencies:
       - fvcore==0.1.5.post20221221
       - gradio==4.22.0
       - gradio-client==0.13.0
-      - gensim==3.8.3
       - greenlet==3.0.3
       - h11==0.14.0
       - html5lib==1.1


### PR DESCRIPTION
`gensim==3.8.3` is an older version that lacks pre-compiled pip wheel packages for Python 3.9. Consequently, pip attempts to compile it locally from C source code, which triggers C-API incompatibility errors. We can leverage Conda's major advantage here: the Conda repository already has pre-compiled binaries for `gensim 3.8.3`. Simply remove `gensim` from the `pip` installation list and add it to Conda's base dependencies list. This way, Conda will directly download the pre-compiled files, completely bypassing the need to invoke the local `gcc` compiler.